### PR TITLE
feat(annotation): bulk-process open annotation issues

### DIFF
--- a/.github/workflows/parse_annotation_issue.yml
+++ b/.github/workflows/parse_annotation_issue.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Ensure git identity
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@://github.com"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Load scripts from main
         run: |

--- a/scripts/parse_issue_annotation.py
+++ b/scripts/parse_issue_annotation.py
@@ -20,6 +20,7 @@ import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 # Logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
@@ -132,110 +133,207 @@ def _parse_regions(regions_raw: str, task_type: str | None = None) -> list[dict]
             
     return regions
 
-def main() -> None:
-    issue_number = os.environ.get("ISSUE_NUMBER", "").strip()
-    issue_body = os.environ.get("ISSUE_BODY", "").strip()
-    issue_author = os.environ.get("ISSUE_AUTHOR", "unknown").strip()
 
-    if not all([issue_number, issue_body]):
-        log.error("Missing ISSUE_NUMBER or ISSUE_BODY")
-        sys.exit(1)
+class AnnotationParseError(Exception):
+    pass
 
+
+def _ordered_task(task: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": task.get("id"),
+        "url": task.get("url"),
+        "task_type": task.get("task_type"),
+        "created_at": task.get("created_at"),
+        "metadata": task.get("metadata"),
+        "annotations": task.get("annotations", []),
+    }
+
+
+def _parse_issue_submission(*, issue_number: Any, issue_body: str, issue_author: str) -> dict[str, Any]:
     fields = _parse_issue_body(issue_body)
     task_type = fields.get("task_type", "").strip().lower()
     record_id = fields.get("record_id", "").strip()
-    
-    # Try multiple common keys for regions
+
     regions_raw = ""
     for key in ["your_label", "label", "pixel_coordinates", "regions", "coordinates"]:
         if fields.get(key):
             regions_raw = fields[key]
             break
-            
+
     confidence_raw = fields.get("confidence_score", "100").strip()
-    
     try:
-        # Extract numeric value, handle % if present
         confidence = float(re.sub(r"[^0-9.]", "", confidence_raw))
-    except ValueError:
-        confidence = 100.0
+    except ValueError as exc:
+        raise AnnotationParseError("confidence_score is invalid") from exc
 
     if task_type not in VALID_TASK_TYPES:
-        log.error(f"Invalid task_type: {task_type}")
-        sys.exit(1)
+        raise AnnotationParseError(f"invalid task_type: {task_type}")
     if not record_id:
-        log.error("record_id is required")
-        sys.exit(1)
+        raise AnnotationParseError("record_id is required")
+    if not (0.0 <= confidence <= 100.0):
+        raise AnnotationParseError("confidence_score must be between 0 and 100")
 
     regions = _parse_regions(regions_raw, task_type)
     if not regions:
-        log.error("No valid regions provided.")
-        sys.exit(1)
+        raise AnnotationParseError("no valid regions provided")
 
-    file_path = ANNOTATIONS_DIR / f"{task_type}.jsonl"
-    if not file_path.exists():
-        log.error(f"Task file {file_path.name} not found")
-        sys.exit(1)
+    normalized_issue_number: Any
+    issue_number_str = str(issue_number).strip()
+    if issue_number_str.isdigit():
+        normalized_issue_number = int(issue_number_str)
+    else:
+        normalized_issue_number = issue_number
 
-    tasks = []
-    found = False
-    try:
+    annotation = {
+        "user": issue_author,
+        "confidence_score": confidence,
+        "locations": regions,
+        "issue_number": normalized_issue_number,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    return {
+        "issue_number": normalized_issue_number,
+        "issue_author": issue_author,
+        "task_type": task_type,
+        "record_id": record_id,
+        "annotation": annotation,
+    }
+
+
+def process_issue_submissions(
+    issues: list[dict[str, Any]], annotations_dir: Path = ANNOTATIONS_DIR
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    parsed: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+
+    for issue in issues:
+        number = issue.get("number")
+        body = str(issue.get("body", "") or "")
+        author = str(issue.get("author", "unknown") or "unknown").strip()
+        try:
+            parsed.append(
+                _parse_issue_submission(
+                    issue_number=number,
+                    issue_body=body,
+                    issue_author=author,
+                )
+            )
+        except AnnotationParseError as exc:
+            failures.append({"number": number, "author": author, "error": str(exc)})
+
+    by_task_type: dict[str, list[dict[str, Any]]] = {}
+    for item in parsed:
+        by_task_type.setdefault(item["task_type"], []).append(item)
+
+    successes: list[dict[str, Any]] = []
+    for task_type, batch in by_task_type.items():
+        file_path = annotations_dir / f"{task_type}.jsonl"
+        if not file_path.exists():
+            for item in batch:
+                failures.append(
+                    {
+                        "number": item["issue_number"],
+                        "author": item["issue_author"],
+                        "error": f"task file {file_path.name} not found",
+                    }
+                )
+            continue
+
+        tasks: list[dict[str, Any]] = []
+        index_by_id: dict[str, int] = {}
         with open(file_path, "r", encoding="utf-8") as f:
-            for line in f:
-                if not line.strip(): continue
+            for idx, line in enumerate(f):
+                if not line.strip():
+                    continue
                 task = json.loads(line)
-                if str(task.get("id")) == record_id:
-                    found = True
-                    
-                    # Remove legacy fields
-                    for legacy in ["user_label", "ml_label", "locations", "serial_number"]:
-                        task.pop(legacy, None)
-                    
-                    # Clean metadata
-                    if isinstance(task.get("metadata"), dict):
-                        for legacy_meta in ["last_user", "last_annotator", "last_timestamp", "last_issue_number"]:
-                            task["metadata"].pop(legacy_meta, None)
 
-                    if "annotations" not in task or not isinstance(task["annotations"], list):
-                        task["annotations"] = []
-                    
-                    # Append new annotation entry
-                    task["annotations"].append({
-                        "user": issue_author,
-                        "locations": regions,
-                        "confidence_score": confidence,
-                        "issue_number": int(issue_number) if str(issue_number).isdigit() else issue_number,
-                        "timestamp": datetime.now(timezone.utc).isoformat()
-                    })
+                for legacy in ["user_label", "ml_label", "locations", "serial_number"]:
+                    task.pop(legacy, None)
+                if isinstance(task.get("metadata"), dict):
+                    for legacy_meta in ["last_user", "last_annotator", "last_timestamp", "last_issue_number"]:
+                        task["metadata"].pop(legacy_meta, None)
+                if not isinstance(task.get("annotations"), list):
+                    task["annotations"] = []
 
-                    # Ensure annotations are chronologically ordered by timestamp
-                    try:
-                        task["annotations"].sort(key=lambda a: a.get("timestamp", ""))
-                    except Exception:
-                        pass
-                
-                # Enforce field order
-                ordered_task = {
-                    "id": task.get("id"),
-                    "url": task.get("url"),
-                    "task_type": task.get("task_type"),
-                    "created_at": task.get("created_at"),
-                    "metadata": task.get("metadata"),
-                    "annotations": task.get("annotations", [])
+                task_id = str(task.get("id", "")).strip()
+                if task_id:
+                    index_by_id[task_id] = idx
+                tasks.append(_ordered_task(task))
+
+        changed = False
+        for item in batch:
+            task_idx = index_by_id.get(item["record_id"])
+            if task_idx is None:
+                failures.append(
+                    {
+                        "number": item["issue_number"],
+                        "author": item["issue_author"],
+                        "error": f"record {item['record_id']} not found",
+                    }
+                )
+                continue
+
+            task = tasks[task_idx]
+            existing_annotations = task["annotations"]
+            already_exists = any(
+                str(existing.get("user", "")).strip().lower() == item["issue_author"].lower()
+                for existing in existing_annotations
+            )
+            if already_exists:
+                failures.append(
+                    {
+                        "number": item["issue_number"],
+                        "author": item["issue_author"],
+                        "error": f"user '{item['issue_author']}' already annotated record {item['record_id']}",
+                    }
+                )
+                continue
+
+            existing_annotations.append(item["annotation"])
+            try:
+                existing_annotations.sort(key=lambda a: a.get("timestamp", ""))
+            except Exception:
+                pass
+            changed = True
+            successes.append(
+                {
+                    "number": item["issue_number"],
+                    "author": item["issue_author"],
+                    "record_id": item["record_id"],
+                    "task_type": item["task_type"],
                 }
-                tasks.append(ordered_task)
-    except Exception as exc:
-        log.error(f"Failed to process {file_path}: {exc}")
+            )
+
+        if changed:
+            with open(file_path, "w", encoding="utf-8") as f:
+                for task in tasks:
+                    f.write(json.dumps(_ordered_task(task), separators=(",", ":")) + "\n")
+
+    return successes, failures
+
+def main() -> None:
+    issue_number = os.environ.get("ISSUE_NUMBER", "").strip()
+    issue_body = os.environ.get("ISSUE_BODY", "").strip()
+    issue_author = os.environ.get("ISSUE_AUTHOR", "unknown").strip()
+    if not all([issue_number, issue_body]):
+        log.error("Missing ISSUE_NUMBER or ISSUE_BODY")
         sys.exit(1)
 
-    if not found:
-        log.error(f"Record {record_id} not found")
+    successes, failures = process_issue_submissions(
+        [{"number": issue_number, "body": issue_body, "author": issue_author}],
+        annotations_dir=ANNOTATIONS_DIR,
+    )
+    if failures:
+        log.error(failures[0]["error"])
+        sys.exit(1)
+    if not successes:
+        log.error("No annotation was processed")
         sys.exit(1)
 
-    with open(file_path, "w", encoding="utf-8") as f:
-        for t in tasks:
-            f.write(json.dumps(t, separators=(",", ":")) + "\n")
-    log.info(f"Updated {record_id} with annotation from {issue_author} (Confidence: {confidence})")
+    success = successes[0]
+    log.info(
+        f"Updated {success['record_id']} ({success['task_type']}) with annotation from {success['author']}"
+    )
 
 if __name__ == "__main__":
     main()

--- a/scripts/process_all_annotation_issues.py
+++ b/scripts/process_all_annotation_issues.py
@@ -7,11 +7,10 @@ Intended to be run inside GitHub Actions with `GITHUB_TOKEN` available.
 from __future__ import annotations
 import json
 import os
-import shlex
 import subprocess
-import sys
 from typing import Any
 import requests
+from scripts.parse_issue_annotation import process_issue_submissions
 
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY")  # owner/repo
@@ -80,25 +79,19 @@ def main() -> None:
     issues = list_annotation_issues()
     print(f"Found {len(issues)} open annotation issues")
     
-    successes = []
-    failures = []
-
-    for issue in issues:
-        num = issue["number"]
-        body = issue.get("body", "")
-        author = issue.get("user", {}).get("login", "unknown")
-        
-        print(f"Processing issue #{num} by {author}")
-        env = os.environ.copy()
-        env["ISSUE_NUMBER"] = str(num)
-        env["ISSUE_BODY"] = body
-        env["ISSUE_AUTHOR"] = author
-        
-        rc, out, err = run_cmd([sys.executable, "scripts/parse_issue_annotation.py"], cwd=repo_dir, env=env)
-        if rc == 0:
-            successes.append({"number": num, "author": author})
-        else:
-            failures.append({"number": num, "error": err})
+    issue_inputs = [
+        {
+            "number": issue["number"],
+            "body": issue.get("body", ""),
+            "author": issue.get("user", {}).get("login", "unknown"),
+        }
+        for issue in issues
+    ]
+    successes, failures = process_issue_submissions(issue_inputs)
+    for success in successes:
+        print(f"Processed issue #{success['number']} by {success['author']}")
+    for failure in failures:
+        print(f"Failed issue #{failure['number']}: {failure['error']}")
 
     # Prepare changes
     run_cmd(["git", "add", "annotations/"], cwd=repo_dir)
@@ -107,7 +100,8 @@ def main() -> None:
     commit_ok = False
     if out2.strip():
         issue_nums = [s["number"] for s in successes]
-        coauthors = "".join([f"Co-authored-by: {s['author']} <>\n" for s in successes])
+        coauthor_authors = sorted({s["author"] for s in successes})
+        coauthors = "".join([f"Co-authored-by: {author} <>\n" for author in coauthor_authors])
         commit_msg = f"chore(annotation): record annotations from issues {', '.join(['#'+str(n) for n in issue_nums])} [skip ci]\n\n{coauthors}"
         
         # Commit locally

--- a/tests/test_parse_issue_annotation.py
+++ b/tests/test_parse_issue_annotation.py
@@ -1,4 +1,11 @@
-from scripts.parse_issue_annotation import _parse_issue_body, _parse_regions, circle_to_rle
+import json
+
+from scripts.parse_issue_annotation import (
+    _parse_issue_body,
+    _parse_regions,
+    circle_to_rle,
+    process_issue_submissions,
+)
 
 
 def test_parse_issue_body_basic():
@@ -43,3 +50,105 @@ def test_circle_to_rle_out_of_bounds():
     # Circle outside the 1024x1024 should return empty string
     rle = circle_to_rle(-100.0, -100.0, 5.0)
     assert rle == ""
+
+
+def test_bulk_processing_updates_once_per_file(tmp_path):
+    annotations_dir = tmp_path / "annotations"
+    annotations_dir.mkdir()
+    sample = {
+        "id": "sp-1",
+        "url": "https://example/sp-1.jpg",
+        "task_type": "sunspot",
+        "created_at": "2026-01-01T00:00:00Z",
+        "metadata": {"source": "test", "captured_at": "2026-01-01T00:00:00Z"},
+        "annotations": [],
+    }
+    with open(annotations_dir / "sunspot.jsonl", "w", encoding="utf-8") as f:
+        f.write(json.dumps(sample, separators=(",", ":")) + "\n")
+
+    body1 = """
+### Task Type
+sunspot
+
+### Record ID
+sp-1
+
+### Your Label (label,x,y,r ; label2,x2,y2,r2)
+class_a,100,100,10
+
+### Confidence Score (0-100)
+90
+"""
+    body2 = """
+### Task Type
+sunspot
+
+### Record ID
+sp-1
+
+### Your Label (label,x,y,r ; label2,x2,y2,r2)
+class_b,120,120,8
+
+### Confidence Score (0-100)
+85
+"""
+    successes, failures = process_issue_submissions(
+        [
+            {"number": 101, "body": body1, "author": "alice"},
+            {"number": 102, "body": body2, "author": "bob"},
+        ],
+        annotations_dir=annotations_dir,
+    )
+
+    assert len(successes) == 2
+    assert failures == []
+
+    lines = (annotations_dir / "sunspot.jsonl").read_text(encoding="utf-8").strip().splitlines()
+    updated = json.loads(lines[0])
+    assert len(updated["annotations"]) == 2
+    assert {a["user"] for a in updated["annotations"]} == {"alice", "bob"}
+
+
+def test_duplicate_user_same_record_rejected(tmp_path):
+    annotations_dir = tmp_path / "annotations"
+    annotations_dir.mkdir()
+    sample = {
+        "id": "mg-1",
+        "url": "https://example/mg-1.jpg",
+        "task_type": "magnetogram",
+        "created_at": "2026-01-01T00:00:00Z",
+        "metadata": {"source": "test", "captured_at": "2026-01-01T00:00:00Z"},
+        "annotations": [
+            {
+                "user": "alice",
+                "confidence_score": 90.0,
+                "locations": [{"label": "alpha", "region": "10,10,5"}],
+                "issue_number": 1,
+                "timestamp": "2026-01-01T00:00:00+00:00",
+            }
+        ],
+    }
+    with open(annotations_dir / "magnetogram.jsonl", "w", encoding="utf-8") as f:
+        f.write(json.dumps(sample, separators=(",", ":")) + "\n")
+
+    body = """
+### Task Type
+magnetogram
+
+### Record ID
+mg-1
+
+### Your Label (label,x,y,r ; label2,x2,y2,r2)
+beta,20,20,6
+
+### Confidence Score (0-100)
+95
+"""
+    successes, failures = process_issue_submissions(
+        [{"number": 2, "body": body, "author": "Alice"}],
+        annotations_dir=annotations_dir,
+    )
+
+    assert successes == []
+    assert len(failures) == 1
+    assert "already annotated record mg-1" in failures[0]["error"]


### PR DESCRIPTION
Improve parser throughput by batching submissions per task file, enforce duplicate-user constraint per record, and return explicit per-issue failures. Also fix parse workflow bot email identity.